### PR TITLE
Handle beta releases while downloading a new version

### DIFF
--- a/systemd/runner.sh
+++ b/systemd/runner.sh
@@ -7,7 +7,7 @@ COMPONENT="node"
 MODE="server"
 
 if [[ "$VERSION" == "latest" ]]; then
-    VERSION=`curl https://github.com/witnet/witnet-rust/releases/latest --cacert /etc/ssl/certs/ca-certificates.crt 2>/dev/null | egrep -o "[0-9|\.]{5}(-rc[0-9]+)?"`
+    VERSION=`curl https://github.com/witnet/witnet-rust/releases/latest --cacert /etc/ssl/certs/ca-certificates.crt 2>/dev/null | egrep -o "[0-9|\.]{5}(-(rc|b)[0-9]*)?"`
 fi
 
 TRIPLET=`bash --version | head -1 | sed -En 's/^.*\ \((.+)-(.+)-(.+)\)$/\1-\2-\3/p'`


### PR DESCRIPTION
Closes #11

The update allows "rc", "b", and any variant containing numbers ("rc1", "b1",...). Before, only "rc1", "rc2",... variants matched the regexp.