### PR TITLE
(feat)Allow to export docker-compose masterKeys to a local archive

### DIFF
--- a/docker/compose/bertux-operator-5/masterKeyExport.sh
+++ b/docker/compose/bertux-operator-5/masterKeyExport.sh
@@ -1,0 +1,1 @@
+../bertux-operator-stable/masterKeyExport.sh

--- a/docker/compose/bertux-operator-5/masterKeyExport.sh
+++ b/docker/compose/bertux-operator-5/masterKeyExport.sh
@@ -1,1 +1,0 @@
-../bertux-operator-stable/masterKeyExport.sh

--- a/docker/compose/bertux-operator-stable/masterKeyExport.sh
+++ b/docker/compose/bertux-operator-stable/masterKeyExport.sh
@@ -16,5 +16,5 @@ for c in $CONTAINERS; do
     mv "$local_key_file" "$output_dir"
 done;
 
-tar -cf "${EXPORT_DIR}".tar "$EXPORT_DIR"
+tar -czf "${EXPORT_DIR}".tar "$EXPORT_DIR"
 

--- a/docker/compose/bertux-operator-stable/masterKeyExport.sh
+++ b/docker/compose/bertux-operator-stable/masterKeyExport.sh
@@ -1,1 +1,20 @@
-docker-compose ps | grep node | cut -d' ' -f1 | parallel docker exec {} ./witnet node masterKeyExport --write
+#!/bin/bash
+
+CONTAINERS=$(docker-compose ps -q)
+EXPORT_DIR="master_keys_$(date +'%Y%m%d%H%M%S')"
+
+mkdir $EXPORT_DIR
+
+for c in $CONTAINERS; do
+    compose_service_name=$(docker inspect $c --format '{{ index .Config.Labels "com.docker.compose.service" }}') 
+    docker_key_file=$(docker exec $c ./witnet node masterKeyExport --write | grep -Po '(Private key written to )\K.*')
+    storage_path=$(docker inspect $c --format '{{ range .Mounts }}{{ if eq .Destination "/.witnet" }}{{ .Source }}{{ end }}{{ end }}') 
+    local_key_file="${storage_path}/${docker_key_file#*/*/}"
+    output_dir="${EXPORT_DIR}/${compose_service_name}"
+    
+    mkdir $output_dir
+    mv "$local_key_file" "$output_dir"
+done;
+
+tar -cf "${EXPORT_DIR}".tar "$EXPORT_DIR"
+

--- a/docker/compose/bertux-operator-stable/masterKeyExport.sh
+++ b/docker/compose/bertux-operator-stable/masterKeyExport.sh
@@ -16,4 +16,4 @@ for c in $CONTAINERS; do
     mv "$local_key_file" "$output_dir"
 done;
 
-tar -czf "${EXPORT_DIR}".tar "$EXPORT_DIR"
+tar -czf "${EXPORT_DIR}".tar "$EXPORT_DIR" && rm -rf "$EXPORT_DIR"


### PR DESCRIPTION
As I have multiple nodes running via the same docker-compose file, i needed something to export all the keys alltogether.

This script creates a directory containing the private keys of all the services, and creates a tar archive containing the same structure.
To avoid conflicts, the folder contains the current date as "yyyymmddHHMMSS"

The created structure is this one :

![image](https://user-images.githubusercontent.com/4500444/85201918-3abd9c00-b303-11ea-8531-840b03f0db25.png)

I don't have a single docker-compose instance running, maybe someone could check it.
It should work the same.
